### PR TITLE
Added the ability to specify the server to use when clients are instantiated

### DIFF
--- a/Tatum/Clients/AdaClient.cs
+++ b/Tatum/Clients/AdaClient.cs
@@ -191,7 +191,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ada";
+            var baseUrl = _serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -227,7 +227,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ada";
+            var baseUrl = _serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -268,7 +268,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ada";
+            var baseUrl = _serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -307,7 +307,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ada";
+            var baseUrl = _serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/AdaClient.cs
+++ b/Tatum/Clients/AdaClient.cs
@@ -21,9 +21,11 @@ namespace Tatum
     {
 
         private readonly string _privateKey;
-        public AdaClient(string privateKey)
+        private readonly string _serverUrl;
+        public AdaClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -189,7 +191,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ada";
+            var baseUrl = serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -225,7 +227,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ada";
+            var baseUrl = serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -266,7 +268,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ada";
+            var baseUrl = serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -305,7 +307,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ada";
+            var baseUrl = serverUrl + "/v3/ada";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BinanceClient.cs
+++ b/Tatum/Clients/BinanceClient.cs
@@ -157,7 +157,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bnb";
+            var baseUrl = _serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -193,7 +193,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bnb";
+            var baseUrl = _serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -234,7 +234,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bnb";
+            var baseUrl = _serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -273,7 +273,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bnb";
+            var baseUrl = _serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BinanceClient.cs
+++ b/Tatum/Clients/BinanceClient.cs
@@ -25,9 +25,11 @@ namespace Tatum
     {
 
         private readonly string _privateKey;
-        public BinanceClient(string privateKey)
+        private readonly string _serverUrl;
+        public BinanceClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -155,7 +157,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bnb";
+            var baseUrl = serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -191,7 +193,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bnb";
+            var baseUrl = serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -232,7 +234,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bnb";
+            var baseUrl = serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -271,7 +273,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bnb";
+            var baseUrl = serverUrl + "/v3/bnb";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BitcoinCashClient.cs
+++ b/Tatum/Clients/BitcoinCashClient.cs
@@ -244,7 +244,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bcash";
+            var baseUrl = _serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -280,7 +280,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bcash";
+            var baseUrl = _serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -321,7 +321,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bcash";
+            var baseUrl = _serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -360,7 +360,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bcash";
+            var baseUrl = _serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BitcoinCashClient.cs
+++ b/Tatum/Clients/BitcoinCashClient.cs
@@ -26,9 +26,11 @@ namespace Tatum
     public class BitcoinCashClient : IBitcoinCashClient
     {
         private readonly string _privateKey;
-        public BitcoinCashClient(string privateKey)
+        private readonly string _serverUrl;
+        public BitcoinCashClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -242,7 +244,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bcash";
+            var baseUrl = serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -278,7 +280,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bcash";
+            var baseUrl = serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -319,7 +321,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bcash";
+            var baseUrl = serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -358,7 +360,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bcash";
+            var baseUrl = serverUrl + "/v3/bcash";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BitcoinClient.cs
+++ b/Tatum/Clients/BitcoinClient.cs
@@ -341,7 +341,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bitcoin";
+            var baseUrl = _serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -377,7 +377,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bitcoin";
+            var baseUrl = _serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -418,7 +418,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bitcoin";
+            var baseUrl = _serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -457,7 +457,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bitcoin";
+            var baseUrl = _serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BitcoinClient.cs
+++ b/Tatum/Clients/BitcoinClient.cs
@@ -21,9 +21,11 @@ namespace Tatum
     public partial class BitcoinClient : IBitcoinClient
     {
         private readonly string _privateKey;
-        public BitcoinClient(string privateKey)
+        private readonly string _serverUrl;
+        public BitcoinClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -339,7 +341,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bitcoin";
+            var baseUrl = serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -375,7 +377,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bitcoin";
+            var baseUrl = serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -416,7 +418,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bitcoin";
+            var baseUrl = serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -455,7 +457,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bitcoin";
+            var baseUrl = serverUrl + "/v3/bitcoin";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BscClient.cs
+++ b/Tatum/Clients/BscClient.cs
@@ -35,9 +35,11 @@ namespace Tatum
     {
 
         private readonly string _privateKey;
-        public BscClient(string privateKey)
+        private readonly string _serverUrl;
+        public BscClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -1668,7 +1670,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bsc";
+            var baseUrl = serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1704,7 +1706,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bsc";
+            var baseUrl = serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1745,7 +1747,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/bsc";
+            var baseUrl = serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1784,7 +1786,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/bsc";
+            var baseUrl = serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/BscClient.cs
+++ b/Tatum/Clients/BscClient.cs
@@ -1670,7 +1670,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bsc";
+            var baseUrl = _serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1706,7 +1706,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bsc";
+            var baseUrl = _serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1747,7 +1747,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/bsc";
+            var baseUrl = _serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1786,7 +1786,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/bsc";
+            var baseUrl = _serverUrl + "/v3/bsc";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/CeloClient.cs
+++ b/Tatum/Clients/CeloClient.cs
@@ -31,9 +31,11 @@ namespace Tatum
     public class CeloClient: ICeloClient
     {
         private readonly string _privateKey;
-        public CeloClient(string privateKey)
+        private readonly string _serverUrl;
+        public CeloClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -1507,7 +1509,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/celo";
+            var baseUrl = serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1543,7 +1545,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/celo";
+            var baseUrl = serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1584,7 +1586,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/celo";
+            var baseUrl = serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1623,7 +1625,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/celo";
+            var baseUrl = serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/CeloClient.cs
+++ b/Tatum/Clients/CeloClient.cs
@@ -1509,7 +1509,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/celo";
+            var baseUrl = _serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1545,7 +1545,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/celo";
+            var baseUrl = _serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1586,7 +1586,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/celo";
+            var baseUrl = _serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1625,7 +1625,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/celo";
+            var baseUrl = _serverUrl + "/v3/celo";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/DogecoinClient.cs
+++ b/Tatum/Clients/DogecoinClient.cs
@@ -25,9 +25,11 @@ namespace Tatum
     public class DogeClient : IDogecoinClient
     {
         private readonly string _privateKey;
-        public DogeClient(string privateKey)
+        private readonly string _serverUrl;
+        public DogeClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -342,7 +344,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/dogecoin";
+            var baseUrl = serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -378,7 +380,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/dogecoin";
+            var baseUrl = serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -419,7 +421,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/dogecoin";
+            var baseUrl = serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -458,7 +460,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/dogecoin";
+            var baseUrl = serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/DogecoinClient.cs
+++ b/Tatum/Clients/DogecoinClient.cs
@@ -344,7 +344,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/dogecoin";
+            var baseUrl = _serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -380,7 +380,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/dogecoin";
+            var baseUrl = _serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -421,7 +421,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/dogecoin";
+            var baseUrl = _serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -460,7 +460,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/dogecoin";
+            var baseUrl = _serverUrl + "/v3/dogecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/EthereumClient.cs
+++ b/Tatum/Clients/EthereumClient.cs
@@ -1658,7 +1658,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path,string headerparameter, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ethereum";
+            var baseUrl = _serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1695,7 +1695,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string headerparameter, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ethereum";
+            var baseUrl = _serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1737,7 +1737,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ethereum";
+            var baseUrl = _serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1776,7 +1776,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ethereum";
+            var baseUrl = _serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/EthereumClient.cs
+++ b/Tatum/Clients/EthereumClient.cs
@@ -32,9 +32,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public EthereumClient(string privateKey)
+        private readonly string _serverUrl;
+        public EthereumClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -1656,7 +1658,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path,string headerparameter, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ethereum";
+            var baseUrl = serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1693,7 +1695,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string headerparameter, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ethereum";
+            var baseUrl = serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1735,7 +1737,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ethereum";
+            var baseUrl = serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1774,7 +1776,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ethereum";
+            var baseUrl = serverUrl + "/v3/ethereum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/FabricClient.cs
+++ b/Tatum/Clients/FabricClient.cs
@@ -21,11 +21,11 @@ namespace Tatum
     {
 
         private readonly string _privateKey;
-        public FabricClient(string privateKey)
+        private readonly string _serverUrl;
+        public FabricClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
-
-
+            _serverUrl = serverUrl;
         }
 
 
@@ -64,7 +64,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/fabric";
+            var baseUrl = serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -100,7 +100,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/fabric";
+            var baseUrl = serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -141,7 +141,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/fabric";
+            var baseUrl = serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -180,7 +180,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/fabric";
+            var baseUrl = serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/FabricClient.cs
+++ b/Tatum/Clients/FabricClient.cs
@@ -64,7 +64,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/fabric";
+            var baseUrl = _serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -100,7 +100,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/fabric";
+            var baseUrl = _serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -141,7 +141,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/fabric";
+            var baseUrl = _serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -180,7 +180,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/fabric";
+            var baseUrl = _serverUrl + "/v3/fabric";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/FlowClient.cs
+++ b/Tatum/Clients/FlowClient.cs
@@ -20,9 +20,11 @@ namespace Tatum
     public class FlowClient
     {
         private readonly string _privateKey;
-        public FlowClient(string privateKey)
+        private readonly string _serverUrl;
+        public FlowClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -283,7 +285,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/flow";
+            var baseUrl = serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -319,7 +321,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/flow";
+            var baseUrl = serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -360,7 +362,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/flow";
+            var baseUrl = serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -399,7 +401,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/flow";
+            var baseUrl = serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/FlowClient.cs
+++ b/Tatum/Clients/FlowClient.cs
@@ -285,7 +285,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/flow";
+            var baseUrl = _serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -321,7 +321,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/flow";
+            var baseUrl = _serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -362,7 +362,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/flow";
+            var baseUrl = _serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -401,7 +401,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/flow";
+            var baseUrl = _serverUrl + "/v3/flow";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/FungibleTokenClient.cs
+++ b/Tatum/Clients/FungibleTokenClient.cs
@@ -30,9 +30,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public FungibleTokenClient(string privateKey)
+        private readonly string _serverUrl;
+        public FungibleTokenClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -309,7 +311,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/token";
+            var baseUrl = serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -345,7 +347,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/token";
+            var baseUrl = serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -386,7 +388,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/token";
+            var baseUrl = serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -425,7 +427,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/token";
+            var baseUrl = serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/FungibleTokenClient.cs
+++ b/Tatum/Clients/FungibleTokenClient.cs
@@ -311,7 +311,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/blockchain/token";
+            var baseUrl = _serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -347,7 +347,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/blockchain/token";
+            var baseUrl = _serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -388,7 +388,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/blockchain/token";
+            var baseUrl = _serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -427,7 +427,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/blockchain/token";
+            var baseUrl = _serverUrl + "/v3/blockchain/token";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/HarmonyOneClient.cs
+++ b/Tatum/Clients/HarmonyOneClient.cs
@@ -1633,7 +1633,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/one";
+            var baseUrl = _serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1669,7 +1669,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/one";
+            var baseUrl = _serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1710,7 +1710,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/one";
+            var baseUrl = _serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1749,7 +1749,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/one";
+            var baseUrl = _serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/HarmonyOneClient.cs
+++ b/Tatum/Clients/HarmonyOneClient.cs
@@ -34,9 +34,11 @@ namespace Tatum
     public class HarmonyOneClient: IHarmonyoneClient
     {
         private readonly string _privateKey;
-        public HarmonyOneClient(string privateKey)
+        private readonly string _serverUrl;
+        public HarmonyOneClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -1631,7 +1633,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/one";
+            var baseUrl = serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1667,7 +1669,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/one";
+            var baseUrl = serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1708,7 +1710,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/one";
+            var baseUrl = serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1747,7 +1749,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/one";
+            var baseUrl = serverUrl + "/v3/one";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/IpfsClient.cs
+++ b/Tatum/Clients/IpfsClient.cs
@@ -19,9 +19,11 @@ namespace Tatum
      {
 
         private readonly string _privateKey;
-        public IpfsClient(string privateKey)
+        private readonly string _serverUrl;
+        public IpfsClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -88,7 +90,7 @@ namespace Tatum
 
         public async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ipfs";
+            var baseUrl = serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -124,7 +126,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ipfs";
+            var baseUrl = serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -165,7 +167,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ipfs";
+            var baseUrl = serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -204,7 +206,7 @@ namespace Tatum
 
         public async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ipfs";
+            var baseUrl = serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/IpfsClient.cs
+++ b/Tatum/Clients/IpfsClient.cs
@@ -90,7 +90,7 @@ namespace Tatum
 
         public async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ipfs";
+            var baseUrl = _serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -126,7 +126,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ipfs";
+            var baseUrl = _serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -167,7 +167,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ipfs";
+            var baseUrl = _serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -206,7 +206,7 @@ namespace Tatum
 
         public async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ipfs";
+            var baseUrl = _serverUrl + "/v3/ipfs";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/KmsClient.cs
+++ b/Tatum/Clients/KmsClient.cs
@@ -94,7 +94,7 @@ public partial class KmsClient:IKmsClient
 
         private async Task<string> GetSecureSecurityRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/security";
+            var baseUrl = _serverUrl + "/v3/security";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -127,7 +127,7 @@ public partial class KmsClient:IKmsClient
         }
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
     {
-        var baseUrl = serverUrl + "/v3/kms";
+        var baseUrl = _serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 
@@ -163,7 +163,7 @@ public partial class KmsClient:IKmsClient
     private async Task<string> PostSecureRequest(string path, string parameters)
     {
 
-        var baseUrl = serverUrl + "/v3/kms";
+        var baseUrl = _serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 
@@ -204,7 +204,7 @@ public partial class KmsClient:IKmsClient
     private async Task<string> PUTSecureRequest(string path, string parameters)
     {
 
-        var baseUrl = serverUrl + "/v3/kms";
+        var baseUrl = _serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 
@@ -243,7 +243,7 @@ public partial class KmsClient:IKmsClient
 
     private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
     {
-        var baseUrl = serverUrl + "/v3/kms";
+        var baseUrl = _serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/KmsClient.cs
+++ b/Tatum/Clients/KmsClient.cs
@@ -19,12 +19,13 @@ namespace Tatum {
 public partial class KmsClient:IKmsClient
 {
     private readonly string _privateKey;
+        private readonly string _serverUrl;
 
-    public KmsClient(string privateKey)
-    {
-
-        _privateKey = privateKey;
-    }
+    public KmsClient(string privateKey, string serverUrl)
+        {
+            _privateKey = privateKey;
+            _serverUrl = serverUrl;
+        }
 
 
 
@@ -93,7 +94,7 @@ public partial class KmsClient:IKmsClient
 
         private async Task<string> GetSecureSecurityRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/security";
+            var baseUrl = serverUrl + "/v3/security";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -126,7 +127,7 @@ public partial class KmsClient:IKmsClient
         }
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
     {
-        var baseUrl = "https://api-eu1.tatum.io/v3/kms";
+        var baseUrl = serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 
@@ -162,7 +163,7 @@ public partial class KmsClient:IKmsClient
     private async Task<string> PostSecureRequest(string path, string parameters)
     {
 
-        var baseUrl = "https://api-eu1.tatum.io/v3/kms";
+        var baseUrl = serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 
@@ -203,7 +204,7 @@ public partial class KmsClient:IKmsClient
     private async Task<string> PUTSecureRequest(string path, string parameters)
     {
 
-        var baseUrl = "https://api-eu1.tatum.io/v3/kms";
+        var baseUrl = serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 
@@ -242,7 +243,7 @@ public partial class KmsClient:IKmsClient
 
     private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
     {
-        var baseUrl = "https://api-eu1.tatum.io/v3/kms";
+        var baseUrl = serverUrl + "/v3/kms";
 
         baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/LedgerClient.cs
+++ b/Tatum/Clients/LedgerClient.cs
@@ -559,7 +559,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters=null)
         {
-            var baseUrl = serverUrl + "/v3/ledger";
+            var baseUrl = _serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -595,7 +595,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ledger";
+            var baseUrl = _serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -636,7 +636,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/ledger";
+            var baseUrl = _serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -675,7 +675,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/ledger";
+            var baseUrl = _serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/LedgerClient.cs
+++ b/Tatum/Clients/LedgerClient.cs
@@ -20,11 +20,12 @@ namespace Tatum
     {
        
         private readonly string _privateKey;
+        private readonly string _serverUrl;
 
-        public LedgerClient( string privateKey)
+        public LedgerClient(string privateKey, string serverUrl)
         {
-           
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -558,7 +559,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters=null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ledger";
+            var baseUrl = serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -594,7 +595,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ledger";
+            var baseUrl = serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -635,7 +636,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/ledger";
+            var baseUrl = serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -674,7 +675,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/ledger";
+            var baseUrl = serverUrl + "/v3/ledger";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/LitecoinClient.cs
+++ b/Tatum/Clients/LitecoinClient.cs
@@ -287,7 +287,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/litecoin";
+            var baseUrl = _serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -323,7 +323,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/litecoin";
+            var baseUrl = _serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -364,7 +364,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/litecoin";
+            var baseUrl = _serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -403,7 +403,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/litecoin";
+            var baseUrl = _serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/LitecoinClient.cs
+++ b/Tatum/Clients/LitecoinClient.cs
@@ -25,9 +25,11 @@ namespace Tatum
     public class LitecoinClient:ILitecoinClient
     {
         private readonly string _privateKey;
-        public LitecoinClient(string privateKey)
+        private readonly string _serverUrl;
+        public LitecoinClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -285,7 +287,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/litecoin";
+            var baseUrl = serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -321,7 +323,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/litecoin";
+            var baseUrl = serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -362,7 +364,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/litecoin";
+            var baseUrl = serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -401,7 +403,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/litecoin";
+            var baseUrl = serverUrl + "/v3/litecoin";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/MarketplaceClient.cs
+++ b/Tatum/Clients/MarketplaceClient.cs
@@ -450,7 +450,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
+            var baseUrl = _serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -486,7 +486,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
+            var baseUrl = _serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -527,7 +527,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
+            var baseUrl = _serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -566,7 +566,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
+            var baseUrl = _serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/MarketplaceClient.cs
+++ b/Tatum/Clients/MarketplaceClient.cs
@@ -21,9 +21,11 @@ namespace Tatum
     public class MarketplaceClient
     {
         private readonly string _privateKey;
-        public MarketplaceClient(string privateKey)
+        private readonly string _serverUrl;
+        public MarketplaceClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -448,7 +450,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/marketplace";
+            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -484,7 +486,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/marketplace";
+            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -525,7 +527,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/marketplace";
+            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -564,7 +566,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain/marketplace";
+            var baseUrl = serverUrl + "/v3/blockchain/marketplace";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/MultiTokenClient.cs
+++ b/Tatum/Clients/MultiTokenClient.cs
@@ -2401,7 +2401,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/multitoken";
+            var baseUrl = _serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2437,7 +2437,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/multitoken";
+            var baseUrl = _serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2478,7 +2478,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/multitoken";
+            var baseUrl = _serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2517,7 +2517,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/multitoken";
+            var baseUrl = _serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/MultiTokenClient.cs
+++ b/Tatum/Clients/MultiTokenClient.cs
@@ -31,9 +31,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public MultiTokenClient(string privateKey)
+        private readonly string _serverUrl;
+        public MultiTokenClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -2399,7 +2401,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/multitoken";
+            var baseUrl = serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2435,7 +2437,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/multitoken";
+            var baseUrl = serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2476,7 +2478,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/multitoken";
+            var baseUrl = serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2515,7 +2517,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/multitoken";
+            var baseUrl = serverUrl + "/v3/multitoken";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/NeoClient.cs
+++ b/Tatum/Clients/NeoClient.cs
@@ -225,7 +225,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/neo";
+            var baseUrl = _serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -261,7 +261,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/neo";
+            var baseUrl = _serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -302,7 +302,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/neo";
+            var baseUrl = _serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -341,7 +341,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/neo";
+            var baseUrl = _serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/NeoClient.cs
+++ b/Tatum/Clients/NeoClient.cs
@@ -26,10 +26,12 @@ namespace Tatum
 
 
         private readonly string _privateKey;
+        private readonly string _serverUrl;
         private KeyPair keyPair;
-        public NeoClient(string privateKey)
+        public NeoClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -223,7 +225,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/neo";
+            var baseUrl = serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -259,7 +261,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/neo";
+            var baseUrl = serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -300,7 +302,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/neo";
+            var baseUrl = serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -339,7 +341,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/neo";
+            var baseUrl = serverUrl + "/v3/neo";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/NftClient.cs
+++ b/Tatum/Clients/NftClient.cs
@@ -32,9 +32,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public NftClient(string privateKey)
+        private readonly string _serverUrl;
+        public NftClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -2708,7 +2710,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/nft";
+            var baseUrl = serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2744,7 +2746,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/nft";
+            var baseUrl = serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2785,7 +2787,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/nft";
+            var baseUrl = serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2824,7 +2826,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/nft";
+            var baseUrl = serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/NftClient.cs
+++ b/Tatum/Clients/NftClient.cs
@@ -2710,7 +2710,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/nft";
+            var baseUrl = _serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2746,7 +2746,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/nft";
+            var baseUrl = _serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2787,7 +2787,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/nft";
+            var baseUrl = _serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -2826,7 +2826,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/nft";
+            var baseUrl = _serverUrl + "/v3/nft";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/OffchainClient.cs
+++ b/Tatum/Clients/OffchainClient.cs
@@ -463,7 +463,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/offchain";
+            var baseUrl = _serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -499,7 +499,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/offchain";
+            var baseUrl = _serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -540,7 +540,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/offchain";
+            var baseUrl = _serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -579,7 +579,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/offchain";
+            var baseUrl = _serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/OffchainClient.cs
+++ b/Tatum/Clients/OffchainClient.cs
@@ -29,9 +29,11 @@ namespace Tatum
     public partial class OffchainClient
     {
         private readonly string _privateKey;
-        public OffchainClient(string privateKey)
+        private readonly string _serverUrl;
+        public OffchainClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -461,7 +463,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/offchain";
+            var baseUrl = serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -497,7 +499,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/offchain";
+            var baseUrl = serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -538,7 +540,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/offchain";
+            var baseUrl = serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -577,7 +579,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/offchain";
+            var baseUrl = serverUrl + "/v3/offchain";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/PolygonClient.cs
+++ b/Tatum/Clients/PolygonClient.cs
@@ -34,9 +34,11 @@ namespace Tatum
     public class PolygonClient:IPolygonClient
     {
         private readonly string _privateKey;
-        public PolygonClient(string privateKey)
+        private readonly string _serverUrl;
+        public PolygonClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -1721,7 +1723,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/polygon";
+            var baseUrl = serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1757,7 +1759,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/polygon";
+            var baseUrl = serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1798,7 +1800,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/polygon";
+            var baseUrl = serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1837,7 +1839,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/polygon";
+            var baseUrl = serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/PolygonClient.cs
+++ b/Tatum/Clients/PolygonClient.cs
@@ -1723,7 +1723,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/polygon";
+            var baseUrl = _serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1759,7 +1759,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/polygon";
+            var baseUrl = _serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1800,7 +1800,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/polygon";
+            var baseUrl = _serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1839,7 +1839,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/polygon";
+            var baseUrl = _serverUrl + "/v3/polygon";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/QtumClient.cs
+++ b/Tatum/Clients/QtumClient.cs
@@ -26,9 +26,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public QtumClient(string privateKey)
+        private readonly string _serverUrl;
+        public QtumClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -325,7 +327,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/qtum";
+            var baseUrl = serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -361,7 +363,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/qtum";
+            var baseUrl = serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -402,7 +404,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/qtum";
+            var baseUrl = serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -441,7 +443,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/qtum";
+            var baseUrl = serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/QtumClient.cs
+++ b/Tatum/Clients/QtumClient.cs
@@ -327,7 +327,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/qtum";
+            var baseUrl = _serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -363,7 +363,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/qtum";
+            var baseUrl = _serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -404,7 +404,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/qtum";
+            var baseUrl = _serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -443,7 +443,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/qtum";
+            var baseUrl = _serverUrl + "/v3/qtum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/QuorumClient.cs
+++ b/Tatum/Clients/QuorumClient.cs
@@ -132,7 +132,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/quorum";
+            var baseUrl = _serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -168,7 +168,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/quorum";
+            var baseUrl = _serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -209,7 +209,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/quorum";
+            var baseUrl = _serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -248,7 +248,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/quorum";
+            var baseUrl = _serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/QuorumClient.cs
+++ b/Tatum/Clients/QuorumClient.cs
@@ -23,9 +23,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public QuorumClient(string privateKey)
+        private readonly string _serverUrl;
+        public QuorumClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -130,7 +132,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/quorum";
+            var baseUrl = serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -166,7 +168,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/quorum";
+            var baseUrl = serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -207,7 +209,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/quorum";
+            var baseUrl = serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -246,7 +248,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/quorum";
+            var baseUrl = serverUrl + "/v3/quorum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/RecordClient.cs
+++ b/Tatum/Clients/RecordClient.cs
@@ -20,9 +20,11 @@ namespace Tatum
     public class RecordClient
     {
         private readonly string _privateKey;
-        public RecordClient(string privateKey)
+        private readonly string _serverUrl;
+        public RecordClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -99,7 +101,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/record";
+            var baseUrl = serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -135,7 +137,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/record";
+            var baseUrl = serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -176,7 +178,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/record";
+            var baseUrl = serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -215,7 +217,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/record";
+            var baseUrl = serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/RecordClient.cs
+++ b/Tatum/Clients/RecordClient.cs
@@ -101,7 +101,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/record";
+            var baseUrl = _serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -137,7 +137,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/record";
+            var baseUrl = _serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -178,7 +178,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/record";
+            var baseUrl = _serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -217,7 +217,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/record";
+            var baseUrl = _serverUrl + "/v3/record";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/ScryptaClient.cs
+++ b/Tatum/Clients/ScryptaClient.cs
@@ -25,9 +25,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public ScryptaClient(string privateKey)
+        private readonly string _serverUrl;
+        public ScryptaClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -200,7 +202,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/scrypta";
+            var baseUrl = serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -236,7 +238,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/scrypta";
+            var baseUrl = serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -277,7 +279,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/scrypta";
+            var baseUrl = serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -316,7 +318,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/scrypta";
+            var baseUrl = serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/ScryptaClient.cs
+++ b/Tatum/Clients/ScryptaClient.cs
@@ -202,7 +202,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/scrypta";
+            var baseUrl = _serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -238,7 +238,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/scrypta";
+            var baseUrl = _serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -279,7 +279,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/scrypta";
+            var baseUrl = _serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -318,7 +318,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/scrypta";
+            var baseUrl = _serverUrl + "/v3/scrypta";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/ServiceClient.cs
+++ b/Tatum/Clients/ServiceClient.cs
@@ -142,7 +142,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/tatum";
+            var baseUrl = _serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -178,7 +178,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/tatum";
+            var baseUrl = _serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -219,7 +219,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/tatum";
+            var baseUrl = _serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -258,7 +258,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/tatum";
+            var baseUrl = _serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/ServiceClient.cs
+++ b/Tatum/Clients/ServiceClient.cs
@@ -21,9 +21,11 @@ namespace Tatum
     {
 
         private readonly string _privateKey;
-        public ServiceClient(string privateKey)
+        private readonly string _serverUrl;
+        public ServiceClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -140,7 +142,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/tatum";
+            var baseUrl = serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -176,7 +178,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/tatum";
+            var baseUrl = serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -217,7 +219,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/tatum";
+            var baseUrl = serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -256,7 +258,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/tatum";
+            var baseUrl = serverUrl + "/v3/tatum";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/TronClient.cs
+++ b/Tatum/Clients/TronClient.cs
@@ -321,7 +321,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/tron";
+            var baseUrl = _serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -357,7 +357,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/tron";
+            var baseUrl = _serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -398,7 +398,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/tron";
+            var baseUrl = _serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -437,7 +437,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/tron";
+            var baseUrl = _serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/TronClient.cs
+++ b/Tatum/Clients/TronClient.cs
@@ -21,9 +21,11 @@ namespace Tatum
     public class TronClient
     {
         private readonly string _privateKey;
-        public TronClient(string privateKey)
+        private readonly string _serverUrl;
+        public TronClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -319,7 +321,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/tron";
+            var baseUrl = serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -355,7 +357,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/tron";
+            var baseUrl = serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -396,7 +398,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/tron";
+            var baseUrl = serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -435,7 +437,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/tron";
+            var baseUrl = serverUrl + "/v3/tron";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/UtilsClient.cs
+++ b/Tatum/Clients/UtilsClient.cs
@@ -20,9 +20,11 @@ namespace Tatum
     public class UtilsClient
     {
         private readonly string _privateKey;
-        public UtilsClient(string privateKey)
+        private readonly string _serverUrl;
+        public UtilsClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -330,7 +332,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain";
+            var baseUrl = serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -366,7 +368,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain";
+            var baseUrl = serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -407,7 +409,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain";
+            var baseUrl = serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -446,7 +448,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/blockchain";
+            var baseUrl = serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/UtilsClient.cs
+++ b/Tatum/Clients/UtilsClient.cs
@@ -332,7 +332,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/blockchain";
+            var baseUrl = _serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -368,7 +368,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/blockchain";
+            var baseUrl = _serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -409,7 +409,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/blockchain";
+            var baseUrl = _serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -448,7 +448,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/blockchain";
+            var baseUrl = _serverUrl + "/v3/blockchain";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/VechainClient.cs
+++ b/Tatum/Clients/VechainClient.cs
@@ -34,9 +34,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public VechainClient(string privateKey)
+        private readonly string _serverUrl;
+        public VechainClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -264,7 +266,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/vet";
+            var baseUrl = serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -300,7 +302,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/vet";
+            var baseUrl = serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -341,7 +343,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/vet";
+            var baseUrl = serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -380,7 +382,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/vet";
+            var baseUrl = serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/VechainClient.cs
+++ b/Tatum/Clients/VechainClient.cs
@@ -266,7 +266,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/vet";
+            var baseUrl = _serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -302,7 +302,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/vet";
+            var baseUrl = _serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -343,7 +343,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/vet";
+            var baseUrl = _serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -382,7 +382,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/vet";
+            var baseUrl = _serverUrl + "/v3/vet";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/XLMClient.cs
+++ b/Tatum/Clients/XLMClient.cs
@@ -237,7 +237,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/xlm";
+            var baseUrl = _serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -273,7 +273,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/xlm";
+            var baseUrl = _serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -314,7 +314,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/xlm";
+            var baseUrl = _serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -353,7 +353,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/xlm";
+            var baseUrl = _serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/XLMClient.cs
+++ b/Tatum/Clients/XLMClient.cs
@@ -25,9 +25,11 @@ namespace Tatum
     {
 
         private readonly string _privateKey;
-        public XLMClient(string privateKey)
+        private readonly string _serverUrl;
+        public XLMClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -235,7 +237,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/xlm";
+            var baseUrl = serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -271,7 +273,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/xlm";
+            var baseUrl = serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -312,7 +314,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/xlm";
+            var baseUrl = serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -351,7 +353,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/xlm";
+            var baseUrl = serverUrl + "/v3/xlm";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/XdcClient.cs
+++ b/Tatum/Clients/XdcClient.cs
@@ -37,9 +37,11 @@ namespace Tatum
 
 
         private readonly string _privateKey;
-        public XdcClient(string privateKey)
+        private readonly string _serverUrl;
+        public XdcClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -1633,7 +1635,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/xdc";
+            var baseUrl = serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1669,7 +1671,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/xdc";
+            var baseUrl = serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1710,7 +1712,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/xdc";
+            var baseUrl = serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1749,7 +1751,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/xdc";
+            var baseUrl = serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/XdcClient.cs
+++ b/Tatum/Clients/XdcClient.cs
@@ -1635,7 +1635,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/xdc";
+            var baseUrl = _serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1671,7 +1671,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/xdc";
+            var baseUrl = _serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1712,7 +1712,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/xdc";
+            var baseUrl = _serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -1751,7 +1751,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/xdc";
+            var baseUrl = _serverUrl + "/v3/xdc";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/XrpClient.cs
+++ b/Tatum/Clients/XrpClient.cs
@@ -20,9 +20,11 @@ namespace Tatum
     public class XrpClient
     {
         private readonly string _privateKey;
-        public XrpClient(string privateKey)
+        private readonly string _serverUrl;
+        public XrpClient(string privateKey, string serverUrl)
         {
             _privateKey = privateKey;
+            _serverUrl = serverUrl;
         }
 
 
@@ -321,7 +323,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/xrp";
+            var baseUrl = serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -357,7 +359,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/xrp";
+            var baseUrl = serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -398,7 +400,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = "https://api-eu1.tatum.io/v3/xrp";
+            var baseUrl = serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -437,7 +439,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = "https://api-eu1.tatum.io/v3/xrp";
+            var baseUrl = serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 

--- a/Tatum/Clients/XrpClient.cs
+++ b/Tatum/Clients/XrpClient.cs
@@ -323,7 +323,7 @@ namespace Tatum
 
         private async Task<string> GetSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/xrp";
+            var baseUrl = _serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -359,7 +359,7 @@ namespace Tatum
         private async Task<string> PostSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/xrp";
+            var baseUrl = _serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -400,7 +400,7 @@ namespace Tatum
         private async Task<string> PUTSecureRequest(string path, string parameters)
         {
 
-            var baseUrl = serverUrl + "/v3/xrp";
+            var baseUrl = _serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 
@@ -439,7 +439,7 @@ namespace Tatum
 
         private async Task<string> DeleteSecureRequest(string path, Dictionary<string, string> paramaters = null)
         {
-            var baseUrl = serverUrl + "/v3/xrp";
+            var baseUrl = _serverUrl + "/v3/xrp";
 
             baseUrl = $"{baseUrl}/{path}";
 


### PR DESCRIPTION
I am using the US-WEST1 server but the library has EU1 hardcoded.  I performed an extended find an replace to update the client constructors and internal api calls to require and use a server url string.  If this is something that the community can use, please feel free to include.  Since this is a breaking change for existing users, we could make the new constructor parameter optional and default the value to the EU1 server url which would make the change non-breaking for existing users.  Happy to do that if you would like!

Example:
- **Current State:** MultiTokenClient client = new MultiTokenClient("API KEY");
- **Future State:** MultiTokenClient client = new MultiTokenClient("API KEY", "https://api-us-west1.tatum.io");
